### PR TITLE
Make principals a block per terraform 0.12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "cloudtrail_assume_role" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["cloudtrail.amazonaws.com"]
     }


### PR DESCRIPTION
This is a small change that ought to make us compatible for 0.11 and 0.12 in terraform.