### PR TITLE
Interpolate Cloudwatch Logs Group name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ module "aws_cloudtrail" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| cloudwatch\_log\_group\_name | The name of the CloudWatch Log Group that receives CloudTrail events. | string | `"cloudtrail-events"` | no |
 | log\_retention\_days | Number of days to keep AWS logs around in specific log group. | string | `"90"` | no |
 | org\_trail | Whether or not this is an organization trail. Only valid in master account. | string | `"false"` | no |
 | s3\_bucket\_name | The name of the AWS S3 bucket. | string | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ resource "aws_iam_role" "cloudtrail_cloudwatch_role" {
 
 # This CloudWatch Group is used for storing CloudTrail logs.
 resource "aws_cloudwatch_log_group" "cloudtrail" {
-  name              = "cloudtrail-events"
+  name              = "${var.cloudwatch_log_group_name}"
   retention_in_days = "${var.log_retention_days}"
 }
 
@@ -62,7 +62,7 @@ data "aws_iam_policy_document" "cloudtrail_cloudwatch_logs" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:cloudtrail-events:*"]
+    resources = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${var.cloudwatch_log_group_name}:*"]
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "cloudwatch_log_group_name" {
+  description = "The name of the CloudWatch Log Group that receives CloudTrail events."
+  default     = "cloudtrail-events"
+  type        = "string"
+}
+
 variable "log_retention_days" {
   description = "Number of days to keep AWS logs around in specific log group."
   default     = 90


### PR DESCRIPTION
Simple PR to create a variable for the CloudWatch Logs Group name.  Won't be able to test until I get access to an AWS environment.