### PR TITLE
Organization compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ module "aws_cloudtrail" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | log\_retention\_days | Number of days to keep AWS logs around in specific log group. | string | `"90"` | no |
+| org\_trail | Whether or not this is an organization trail. Only valid in master account. | string | `"false"` | no |
 | s3\_bucket\_name | The name of the AWS S3 bucket. | string | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -89,6 +89,10 @@ resource "aws_cloudtrail" "main" {
   s3_key_prefix  = "cloudtrail"
   s3_bucket_name = "${var.s3_bucket_name}"
 
+  # Note that organization trails can *only* be created in organization
+  # master accounts; this will fail if run in a non-master account.
+  is_organization_trail = "${var.org_trail}"
+
   # use a single s3 bucket for all aws regions
   is_multi_region_trail = true
 

--- a/variables.tf
+++ b/variables.tf
@@ -8,3 +8,8 @@ variable "s3_bucket_name" {
   description = "The name of the AWS S3 bucket."
   type        = "string"
 }
+
+variable "org_trail" {
+  description = "Whether or not this is an organization trail. Only valid in master account."
+  default     = "false"
+  type        = "string"

--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,4 @@ variable "org_trail" {
   description = "Whether or not this is an organization trail. Only valid in master account."
   default     = "false"
   type        = "string"
+}


### PR DESCRIPTION
This just adds a true/false definition for "is_organization_trail" that will let us use this for organizations. I'm not in a hurry to cut another release after this though; we have another change we're looking at as well (adding some of the KMS stuff from https://github.com/nozaq/terraform-aws-secure-baseline/blob/master/modules/cloudtrail-baseline/main.tf to this module), so we can hold off on cutting a release until that's ready.