### PR TITLE
Cleanup simple terratest

### DIFF
--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,10 +1,6 @@
-# Referencing module.logs.aws_logs_bucket directly in the cloudtrail module
-# will fail with an InsufficientS3BucketPolicyException. Using the data
-# source as a workaround to ensure the S3 bucket policy has propagated before
-# the cloudtrail module references it.
 module "aws_cloudtrail" {
   source         = "../../"
-  s3_bucket_name = data.aws_s3_bucket.new_logs_bucket.id
+  s3_bucket_name = module.logs.aws_logs_bucket
 }
 
 module "logs" {
@@ -12,8 +8,4 @@ module "logs" {
   version        = "~> 4"
   s3_bucket_name = var.logs_bucket
   region         = var.region
-}
-
-data "aws_s3_bucket" "new_logs_bucket" {
-  bucket = module.logs.aws_logs_bucket
 }


### PR DESCRIPTION
Prior to this change, referencing module.logs.aws_logs_bucket directly
in the cloudtrail module terratest would fail with an
InsufficientS3BucketPolicyException due to a race condition around how
the aws-logs module attached the bucket policy. v4.1.0 of the aws-logs
module fixed this issue, so the workaround in the cloudtrail terratest
is no longer needed.

https://www.pivotaltracker.com/story/show/169792025

The test still passes with these changes:
```
--- PASS: TestTerraformAwsCloudtrail (37.84s)
PASS
ok  	github.com/trussworks/terraform-aws-cloudtrail/test	37.969s
```