### PR TITLE
Fixes to support terraform-docs 0.8.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:tf12-86954077a1d6587de6c636ed6163001fd0575d87
+      - image: trussworks/circleci-docker-primary:40076395a6e6a349f92caa92c4de614e105fe672
     steps:
       - checkout
       - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,19 +12,18 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.19.0
+    rev: v0.21.0
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.19.0
+    rev: v1.24.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.21.0
+    rev: v1.23.1
     hooks:
       - id: golangci-lint
-        entry: golangci-lint run --verbose
-        verbose: true
+

--- a/README.md
+++ b/README.md
@@ -20,16 +20,22 @@ module "aws_cloudtrail" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| cloudwatch\_log\_group\_name | The name of the CloudWatch Log Group that receives CloudTrail events. | string | `"cloudtrail-events"` | no |
-| encrypt\_cloudtrail | Whether or not to use a custom KMS key to encrypt CloudTrail logs. | string | `"false"` | no |
-| key\_deletion\_window\_in\_days | Duration in days after which the key is deleted after destruction of the resource, must be 7-30 days.  Default 30 days. | string | `"30"` | no |
-| log\_retention\_days | Number of days to keep AWS logs around in specific log group. | string | `"90"` | no |
-| org\_trail | Whether or not this is an organization trail. Only valid in master account. | string | `"false"` | no |
-| s3\_bucket\_name | The name of the AWS S3 bucket. | string | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| cloudwatch\_log\_group\_name | The name of the CloudWatch Log Group that receives CloudTrail events. | `string` | `"cloudtrail-events"` | no |
+| encrypt\_cloudtrail | Whether or not to use a custom KMS key to encrypt CloudTrail logs. | `string` | `"false"` | no |
+| key\_deletion\_window\_in\_days | Duration in days after which the key is deleted after destruction of the resource, must be 7-30 days.  Default 30 days. | `string` | `30` | no |
+| log\_retention\_days | Number of days to keep AWS logs around in specific log group. | `string` | `90` | no |
+| org\_trail | Whether or not this is an organization trail. Only valid in master account. | `string` | `"false"` | no |
+| s3\_bucket\_name | The name of the AWS S3 bucket. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -5,7 +5,8 @@ module "aws_cloudtrail" {
 
 module "logs" {
   source         = "trussworks/logs/aws"
-  version        = "~> 4"
+  version        = "~> 5"
   s3_bucket_name = var.logs_bucket
   region         = var.region
+  force_destroy  = true
 }

--- a/main.tf
+++ b/main.tf
@@ -1,26 +1,3 @@
-/**
- *
- * # Terraform AWS CloudTrail
- *
- * This module creates AWS CloudTrail and configures it so that logs go to cloudwatch.
- *
- * ## Terraform Versions
- *
- * Terraform 0.12. Pin module version to `~> 2.0`. Submit pull-requests to `master` branch.
- *
- * Terraform 0.11. Pin module version to `~> 1.0`. Submit pull-requests to `terraform011` branch.
- *
- * ## Usage
- *
- * ```hcl
- * module "aws_cloudtrail" {
- *     source             = "trussworks/cloudtrail/aws"
- *     s3_bucket_name     = "my-company-cloudtrail-logs"
- *     log_retention_days = 90
- * }
- * ```
- */
-
 # The AWS region currently being used.
 data "aws_region" "current" {
 }

--- a/test/terraform_aws_cloudtrail_test.go
+++ b/test/terraform_aws_cloudtrail_test.go
@@ -29,7 +29,4 @@ func TestTerraformAwsCloudtrail(t *testing.T) {
 
 	defer terraform.Destroy(t, terraformOptions)
 	terraform.InitAndApply(t, terraformOptions)
-
-	// Empty logs_bucket before terraform destroy
-	aws.EmptyS3Bucket(t, awsRegion, bucket)
 }


### PR DESCRIPTION
terraform-docs 0.8 will dump some inline HTML in the readme for object variable, so I've removed the rule from the markdownlint config. I've also removed the redundant documentation in main.tf since that's now maintained in the README directly.

I've also updated the tests to use the `force_destroy` flag to fix intermittent test failures when the logs bucket fails to empty before Terratest triggers a `terrafrom destroy.`