### PR TITLE
Add enabled variable and encrypt CloudWatch log group

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ module "aws_cloudtrail" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
+| cloudwatch\_log\_group\_kms\_key\_arn | The ARN of the KMS key used to encrypt the CloudWatch log group storing CloudTrail logs.  If blank, then logs are unencrypted. | `string` | `""` | no |
 | cloudwatch\_log\_group\_name | The name of the CloudWatch Log Group that receives CloudTrail events. | `string` | `"cloudtrail-events"` | no |
+| cloudwatch\_log\_group\_retention\_in\_days | Number of days to keep the CloudTrail logs in the CloudWatch log group. | `string` | `90` | no |
 | enabled | Enables logging for the trail. Defaults to true. Setting this to false will pause logging. | `bool` | `true` | no |
 | encrypt\_cloudtrail | Whether or not to use a custom KMS key to encrypt CloudTrail logs. | `string` | `"false"` | no |
 | key\_deletion\_window\_in\_days | Duration in days after which the key is deleted after destruction of the resource, must be 7-30 days.  Default 30 days. | `string` | `30` | no |
-| log\_retention\_days | Number of days to keep AWS logs around in specific log group. | `string` | `90` | no |
 | org\_trail | Whether or not this is an organization trail. Only valid in master account. | `string` | `"false"` | no |
 | s3\_bucket\_name | The name of the AWS S3 bucket. | `string` | n/a | yes |
 | s3\_key\_prefix | S3 key prefix for CloudTrail logs | `string` | `"cloudtrail"` | no |
@@ -49,6 +50,12 @@ module "aws_cloudtrail" {
 | cloudtrail\_id | CloudTrail ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Upgrade Paths
+
+### Upgrading from 2.0.4 to 2.1.0
+
+The `log_retention_days` variable is now named `cloudwatch_log_group_retention_in_days`.
 
 ## Developer Setup
 

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,8 @@ resource "aws_iam_role" "cloudtrail_cloudwatch_role" {
 # This CloudWatch Group is used for storing CloudTrail logs.
 resource "aws_cloudwatch_log_group" "cloudtrail" {
   name              = var.cloudwatch_log_group_name
-  retention_in_days = var.log_retention_days
+  retention_in_days = var.cloudwatch_log_group_retention_in_days
+  kms_key_id        = length(var.cloudwatch_log_group_kms_key_arn) > 0 ? var.cloudwatch_log_group_kms_key_arn : null
 
   tags = {
     Automation = "Terraform"

--- a/variables.tf
+++ b/variables.tf
@@ -10,12 +10,6 @@ variable "enabled" {
   type        = bool
 }
 
-variable "log_retention_days" {
-  description = "Number of days to keep AWS logs around in specific log group."
-  default     = 90
-  type        = string
-}
-
 variable "s3_bucket_name" {
   description = "The name of the AWS S3 bucket."
   type        = string
@@ -49,4 +43,16 @@ variable "s3_key_prefix" {
   description = "S3 key prefix for CloudTrail logs"
   default     = "cloudtrail"
   type        = string
+}
+
+variable "cloudwatch_log_group_retention_in_days" {
+  description = "Number of days to keep the CloudTrail logs in the CloudWatch log group."
+  default     = 90
+  type        = string
+}
+
+variable "cloudwatch_log_group_kms_key_arn" {
+  description = "The ARN of the KMS key used to encrypt the CloudWatch log group storing CloudTrail logs.  If blank, then logs are unencrypted."
+  type        = string
+  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -48,7 +48,7 @@ variable "s3_key_prefix" {
 variable "cloudwatch_log_group_retention_in_days" {
   description = "Number of days to keep the CloudTrail logs in the CloudWatch log group."
   default     = 90
-  type        = string
+  type        = number
 }
 
 variable "cloudwatch_log_group_kms_key_arn" {


### PR DESCRIPTION
👋 This PR adds a variable, so one could easily "pause" cloudtrail logging without having to comment out the whole module.  This PR also adds a variable to encrypt the logs when stored in a cloudwatch log group.