### PR TITLE
Add enabled flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ module "aws_cloudtrail" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
 | cloudwatch\_log\_group\_name | The name of the CloudWatch Log Group that receives CloudTrail events. | `string` | `"cloudtrail-events"` | no |
+| enabled | Enables logging for the trail. Defaults to true. Setting this to false will pause logging. | `bool` | `true` | no |
 | encrypt\_cloudtrail | Whether or not to use a custom KMS key to encrypt CloudTrail logs. | `string` | `"false"` | no |
 | key\_deletion\_window\_in\_days | Duration in days after which the key is deleted after destruction of the resource, must be 7-30 days.  Default 30 days. | `string` | `30` | no |
 | log\_retention\_days | Number of days to keep AWS logs around in specific log group. | `string` | `90` | no |

--- a/main.tf
+++ b/main.tf
@@ -255,6 +255,9 @@ resource "aws_cloudtrail" "main" {
 
   kms_key_id = var.encrypt_cloudtrail ? aws_kms_key.cloudtrail[0].arn : null
 
+  # Enables logging for the trail. Defaults to true. Setting this to false will pause logging.
+  enable_logging = var.enabled
+
   tags = {
     Automation = "Terraform"
   }
@@ -264,4 +267,3 @@ resource "aws_cloudtrail" "main" {
     aws_kms_alias.cloudtrail,
   ]
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "cloudwatch_log_group_name" {
   type        = string
 }
 
+variable "enabled" {
+  description = "Enables logging for the trail. Defaults to true. Setting this to false will pause logging."
+  default     = true
+  type        = bool
+}
+
 variable "log_retention_days" {
   description = "Number of days to keep AWS logs around in specific log group."
   default     = 90


### PR DESCRIPTION
This PR simply adds an enabled flag, so CloudTrail can be paused without commenting out the full module.