### PR TITLE
Mandatory encryption for S3 and Cloudwatch Logs

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -3,5 +3,6 @@
   "first-header-h1": false,
   "first-line-h1": false,
   "line_length": false,
-  "no-multiple-blanks": false
+  "no-multiple-blanks": false,
+  "commands-show-output": false
 }

--- a/README.md
+++ b/README.md
@@ -22,18 +22,11 @@ module "aws_cloudtrail" {
 ## Upgrade Instructions for v2 -> v3
 
 Starting in v3, encryption is not optional and will be on for both logs
-delivered to S3 and Cloudwatch Logs. However, because of this change, the
-KMS key resource changes in Terraform, which means you *must* move this
-resource before upgrading if you had encryption on before, or else your
-previous KMS key will be *deleted*. In order to fix this, you need to move
-the resource using a command like so:
+delivered to S3 and Cloudwatch Logs. The KMS key resource created this
+module will be used to encrypt both S3 and Cloudwatch-based logs.
 
-```console
-$ terraform state mv module.my_cloudtrail.aws_kms_key.cloudtrail[0] module.my_cloudtrail.aws_key_key.cloudtrail
-```
-
-You will also need to remove the `encrypt_cloudtrail` parameter from your
-module invocation.
+Because of this change, remove the `encrypt_cloudtrail` parameter from
+previous invocations of the module prior to upgrading the version.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This module creates AWS CloudTrail and configures it so that logs go to cloudwat
 
 ## Terraform Versions
 
-Terraform 0.12. Pin module version to `~> 2.X`. Submit pull-requests to `master` branch.
+Terraform 0.12. Pin module version to `~> 3.X`. Submit pull-requests to `master` branch.
 
 Terraform 0.11. Pin module version to `~> 1.X`. Submit pull-requests to `terraform011` branch.
 
@@ -17,6 +17,19 @@ module "aws_cloudtrail" {
     s3_bucket_name     = "my-company-cloudtrail-logs"
     log_retention_days = 90
 }
+```
+
+## Upgrade Instructions for v2 -> v3
+
+Starting in v3, encryption is not optional and will be on for both logs
+delivered to S3 and Cloudwatch Logs. However, because of this change, the
+KMS key resource changes in Terraform, which means you *must* move this
+resource before upgrading if you had encryption on before, or else your
+previous KMS key will be *deleted*. In order to fix this, you need to move
+the resource using a command like so:
+
+```console
+$ terraform state mv module.my_cloudtrail.aws_kms_key.cloudtrail[0] module.my_cloudtrail.aws_key_key.cloudtrail
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -38,7 +51,6 @@ module "aws_cloudtrail" {
 |------|-------------|------|---------|:--------:|
 | cloudwatch\_log\_group\_name | The name of the CloudWatch Log Group that receives CloudTrail events. | `string` | `"cloudtrail-events"` | no |
 | enabled | Enables logging for the trail. Defaults to true. Setting this to false will pause logging. | `bool` | `true` | no |
-| encrypt\_cloudtrail | Whether or not to use a custom KMS key to encrypt CloudTrail logs. | `string` | `"false"` | no |
 | key\_deletion\_window\_in\_days | Duration in days after which the key is deleted after destruction of the resource, must be 7-30 days.  Default 30 days. | `string` | `30` | no |
 | log\_retention\_days | Number of days to keep AWS logs around in specific log group. | `string` | `90` | no |
 | org\_trail | Whether or not this is an organization trail. Only valid in master account. | `string` | `"false"` | no |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ the resource using a command like so:
 $ terraform state mv module.my_cloudtrail.aws_kms_key.cloudtrail[0] module.my_cloudtrail.aws_key_key.cloudtrail
 ```
 
+You will also need to remove the `encrypt_cloudtrail` parameter from your
+module invocation.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -7,8 +7,6 @@ module "aws_cloudtrail" {
 
   s3_bucket_name = module.logs.aws_logs_bucket
   s3_key_prefix  = var.s3_key_prefix
-
-  encrypt_cloudtrail = var.encrypt_cloudtrail
 }
 
 module "logs" {

--- a/examples/simple/variables.tf
+++ b/examples/simple/variables.tf
@@ -17,7 +17,3 @@ variable "trail_name" {
 variable "cloudwatch_log_group_name" {
   type = string
 }
-
-variable "encrypt_cloudtrail" {
-  type = bool
-}

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,7 @@ resource "aws_iam_role" "cloudtrail_cloudwatch_role" {
 resource "aws_cloudwatch_log_group" "cloudtrail" {
   name              = var.cloudwatch_log_group_name
   retention_in_days = var.log_retention_days
+  kms_key_id        = var.encrypt_cloudtrail ? aws_kms_key.cloudtrail[0].arn : null
 
   tags = {
     Automation = "Terraform"
@@ -206,6 +207,26 @@ data "aws_iam_policy_document" "cloudtrail_kms_policy_doc" {
 
     resources = ["*"]
   }
+
+  statement {
+    sid    = "Allow logs KMS access"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+    }
+
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+    resources = ["*"]
+  }
+
 }
 
 resource "aws_kms_key" "cloudtrail" {

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ resource "aws_iam_role" "cloudtrail_cloudwatch_role" {
 resource "aws_cloudwatch_log_group" "cloudtrail" {
   name              = var.cloudwatch_log_group_name
   retention_in_days = var.log_retention_days
-  kms_key_id        = var.encrypt_cloudtrail ? aws_kms_key.cloudtrail[0].arn : null
+  kms_key_id        = aws_kms_key.cloudtrail.arn
 
   tags = {
     Automation = "Terraform"
@@ -230,8 +230,6 @@ data "aws_iam_policy_document" "cloudtrail_kms_policy_doc" {
 }
 
 resource "aws_kms_key" "cloudtrail" {
-  count = var.encrypt_cloudtrail ? 1 : 0
-
   description             = "A KMS key used to encrypt CloudTrail log files stored in S3."
   deletion_window_in_days = var.key_deletion_window_in_days
   enable_key_rotation     = "true"
@@ -243,10 +241,8 @@ resource "aws_kms_key" "cloudtrail" {
 }
 
 resource "aws_kms_alias" "cloudtrail" {
-  count = var.encrypt_cloudtrail ? 1 : 0
-
   name          = "alias/${var.trail_name}"
-  target_key_id = aws_kms_key.cloudtrail[0].key_id
+  target_key_id = aws_kms_key.cloudtrail.key_id
 }
 
 #
@@ -274,7 +270,7 @@ resource "aws_cloudtrail" "main" {
   # enable log file validation to detect tampering
   enable_log_file_validation = true
 
-  kms_key_id = var.encrypt_cloudtrail ? aws_kms_key.cloudtrail[0].arn : null
+  kms_key_id = aws_kms_key.cloudtrail.arn
 
   # Enables logging for the trail. Defaults to true. Setting this to false will pause logging.
   enable_logging = var.enabled

--- a/test/terraform_aws_cloudtrail_test.go
+++ b/test/terraform_aws_cloudtrail_test.go
@@ -40,35 +40,6 @@ func IsLogging(t *testing.T, region string, trailName string) (bool, error) {
 	return *trailStatus.IsLogging, nil
 }
 
-func TestTerraformAwsCloudtrail(t *testing.T) {
-	testName := fmt.Sprintf("terratest-aws-cloudtrail-%s", strings.ToLower(random.UniqueId()))
-	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/simple")
-
-	terraformOptions := &terraform.Options{
-		TerraformDir: tempTestFolder,
-		Vars: map[string]interface{}{
-			"trail_name":                testName,
-			"cloudwatch_log_group_name": testName,
-			"logs_bucket":               testName,
-			"region":                    awsRegion,
-			"s3_key_prefix":             "testName",
-			"encrypt_cloudtrail":        false,
-		},
-		EnvVars: map[string]string{
-			"AWS_DEFAULT_REGION": awsRegion,
-		},
-	}
-
-	defer terraform.Destroy(t, terraformOptions)
-	terraform.InitAndApply(t, terraformOptions)
-
-	cloudtrailArn := terraform.Output(t, terraformOptions, "cloudtrail_arn")
-	isLogging, err := IsLogging(t, awsRegion, cloudtrailArn)
-	assert.NoError(t, err)
-	assert.True(t, isLogging)
-
-}
-
 func TestTerraformAwsCloudtrailEncryption(t *testing.T) {
 	testName := fmt.Sprintf("terratest-aws-cloudtrail-%s", strings.ToLower(random.UniqueId()))
 	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/simple")
@@ -81,7 +52,6 @@ func TestTerraformAwsCloudtrailEncryption(t *testing.T) {
 			"logs_bucket":               testName,
 			"region":                    awsRegion,
 			"s3_key_prefix":             "testName",
-			"encrypt_cloudtrail":        true,
 		},
 		EnvVars: map[string]string{
 			"AWS_DEFAULT_REGION": awsRegion,

--- a/variables.tf
+++ b/variables.tf
@@ -27,12 +27,6 @@ variable "org_trail" {
   type        = string
 }
 
-variable "encrypt_cloudtrail" {
-  description = "Whether or not to use a custom KMS key to encrypt CloudTrail logs."
-  default     = "false"
-  type        = string
-}
-
 variable "key_deletion_window_in_days" {
   description = "Duration in days after which the key is deleted after destruction of the resource, must be 7-30 days.  Default 30 days."
   default     = 30


### PR DESCRIPTION
I have made encryption non-optional starting in this version (which will be v3) and I'm using the same key for both S3 and Cloudwatch Logs. Because of this change, there is a manual step in order to safely do the upgrade of the module without wiping out the KMS key. I will be testing this version of the module with the git SHA on the Trussworks org just to make sure it works safely.

The ticket for this ask for updates the the tests; I don't think additional tests are necessary to make sure that the Cloudwatch Logs encryption is working, but we could try to parse the Error components of the GetTrailStatusOutput struct if we wanted to, I just don't know if a short-run terratest would actually catch problems with that.