### PR TITLE
Update dependabot from version 1 to public beta version 2

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,4 +1,4 @@
-version: 1
+version: 2
 update_configs:
   # Keep go modules up to date, batching pull requests weekly
   - package_manager: "go:modules"


### PR DESCRIPTION
[Update Dependabot to use new GitHub-integrated version](https://www.pivotaltracker.com/story/show/173667742)

Changes
- what the title says
- this should allow dependabot to tag the `waddlers` github team 