### PR TITLE
maybe fix tf12 logs tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ previous invocations of the module prior to upgrading the version.
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.70 |
+| aws | >= 2.70, < 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.70 |
+| aws | >= 2.70, < 4.0 |
 
 ## Inputs
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -11,7 +11,7 @@ module "aws_cloudtrail" {
 
 module "logs" {
   source  = "trussworks/logs/aws"
-  version = "~> 5"
+  version = "~> 8"
 
   s3_bucket_name = var.logs_bucket
   region         = var.region

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12.0"
 
   required_providers {
-    aws = "~> 2.70"
+    aws = ">= 2.70, < 4.0"
   }
 }


### PR DESCRIPTION
I think this is forcing a weird pick of provider/terraform versions when i run the tests for aws logs