### PR TITLE
Allow setting the role name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "cloudtrail_assume_role" {
 
 # This role is used by CloudTrail to send logs to CloudWatch.
 resource "aws_iam_role" "cloudtrail_cloudwatch_role" {
-  name               = "cloudtrail-cloudwatch-logs-role"
+  name               = var.role_name
   assume_role_policy = data.aws_iam_policy_document.cloudtrail_assume_role.json
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,12 @@ variable "trail_name" {
   type        = string
 }
 
+variable "role_name" {
+  description = "Name for the Cloudtrail Role"
+  default     = "cloudtrail-cloudwatch-logs-role"
+  type        = string
+}
+
 variable "s3_key_prefix" {
   description = "S3 key prefix for CloudTrail logs"
   default     = "cloudtrail"


### PR DESCRIPTION
This patch allows for the role name to be set to some value. This helps
in scenarios where we are importing already pre-existing resources to
terraform.