### PR TITLE
Relax version constraints for Terraform 0.14 and deprecate Terraform 0.11 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     - auth:
         password: $DOCKER_PASSWORD
         username: $DOCKER_USERNAME
-      image: trussworks/circleci:6986bb9022e5a83599feb66a7128a2d0fa12732a
+      image: trussworks/circleci:efb1042e31538677779971798e0912390f699e72
     steps:
     - checkout
     - restore_cache:
@@ -12,11 +12,12 @@ jobs:
         - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
         - go-mod-sources-v1-{{ checksum "go.sum" }}
     - run:
-        command: "temp_role=$(aws sts assume-role \\\n        --role-arn arn:aws:iam::313564602749:role/circleci\
-          \ \\\n        --role-session-name circleci)\nexport AWS_ACCESS_KEY_ID=$(echo\
-          \ $temp_role | jq .Credentials.AccessKeyId | xargs)\nexport AWS_SECRET_ACCESS_KEY=$(echo\
-          \ $temp_role | jq .Credentials.SecretAccessKey | xargs)\nexport AWS_SESSION_TOKEN=$(echo\
-          \ $temp_role | jq .Credentials.SessionToken | xargs)\nmake test\n"
+        command: |
+          temp_role=$(aws sts assume-role --role-arn arn:aws:iam::313564602749:role/circleci --role-session-name circleci)
+          export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
+          export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
+          export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
+          make test
         name: Assume role, run pre-commit and run terratest
     - save_cache:
         key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
@@ -26,8 +27,6 @@ jobs:
         key: go-mod-sources-v1-{{ checksum "go.sum" }}
         paths:
         - ~/go/pkg/mod
-references:
-  circleci: trussworks/circleci:6986bb9022e5a83599feb66a7128a2d0fa12732a
 version: 2.1
 workflows:
   validate:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.4.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,18 +12,18 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.23.2
+    rev: v0.26.0
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.31.0
+    rev: v1.45.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.30.0
+    rev: v1.33.0
     hooks:
       - id: golangci-lint
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@ This module creates AWS CloudTrail and configures it so that logs go to cloudwat
 
 ## Terraform Versions
 
-Terraform 0.13. Pin module version to `~> 4.X`. Submit pull-requests to `master` branch.
+Terraform 0.13 and newer. Pin module version to `~> 4.X`. Submit pull-requests to `master` branch.
 
 Terraform 0.12. Pin module version to `~> 3.X`. Submit pull-requests to `terraform12` branch.
-
-Terraform 0.11. Pin module version to `~> 1.X`. Submit pull-requests to `terraform011` branch.
 
 ## Usage
 
@@ -35,14 +33,14 @@ previous invocations of the module prior to upgrading the version.
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.13.0 |
-| aws | ~> 3.0 |
+| terraform | >= 0.13.0 |
+| aws | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.0 |
+| aws | >= 3.0 |
 
 ## Inputs
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -11,10 +11,9 @@ module "aws_cloudtrail" {
 
 module "logs" {
   source  = "trussworks/logs/aws"
-  version = "~> 9.0.0"
+  version = "~> 10"
 
   s3_bucket_name = var.logs_bucket
-  region         = var.region
 
   cloudtrail_logs_prefix = var.s3_key_prefix
   allow_cloudtrail       = true

--- a/examples/simple/providers.tf
+++ b/examples/simple/providers.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  version = "~> 3.0"
-}

--- a/examples/simple/variables.tf
+++ b/examples/simple/variables.tf
@@ -2,10 +2,6 @@ variable "logs_bucket" {
   type = string
 }
 
-variable "region" {
-  type = string
-}
-
 variable "s3_key_prefix" {
   type = string
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/trussworks/terraform-aws-cloudtrail
 
-go 1.14
+go 1.15
 
 require (
 	github.com/aws/aws-sdk-go v1.36.7

--- a/test/terraform_aws_cloudtrail_test.go
+++ b/test/terraform_aws_cloudtrail_test.go
@@ -50,7 +50,6 @@ func TestTerraformAwsCloudtrailEncryption(t *testing.T) {
 			"trail_name":                testName,
 			"cloudwatch_log_group_name": testName,
 			"logs_bucket":               testName,
-			"region":                    awsRegion,
 			"s3_key_prefix":             "testName",
 		},
 		EnvVars: map[string]string{

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = ">= 3.0"
   }
 }


### PR DESCRIPTION
This will allow folks on Terraform 0.14 to use this module by setting the minimal supported Terraform version. This is aligned with [Terraforms best practices around versioning](https://www.terraform.io/docs/configuration/version-constraints.html#terraform-core-and-provider-versions). CI tests will also will be using the same version.  Tests needed to be updated to remove the no longer needed region variable. Lastly, this PR cleans up the CircleCI config and updates pre-commit hooks. 

Once merged, I will remove the `terraform011` branch.

Resolves https://github.com/trussworks/terraform-aws-cloudtrail/issues/119