### PR TITLE
Customize IAM role name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.33.0
+    rev: v1.34.1
     hooks:
       - id: golangci-lint
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ previous invocations of the module prior to upgrading the version.
 |------|-------------|------|---------|:--------:|
 | cloudwatch\_log\_group\_name | The name of the CloudWatch Log Group that receives CloudTrail events. | `string` | `"cloudtrail-events"` | no |
 | enabled | Enables logging for the trail. Defaults to true. Setting this to false will pause logging. | `bool` | `true` | no |
+| iam\_role\_name | Name for the CloudTrail IAM role | `string` | `"cloudtrail-cloudwatch-logs-role"` | no |
 | key\_deletion\_window\_in\_days | Duration in days after which the key is deleted after destruction of the resource, must be 7-30 days.  Default 30 days. | `string` | `30` | no |
 | log\_retention\_days | Number of days to keep AWS logs around in specific log group. | `string` | `90` | no |
 | org\_trail | Whether or not this is an organization trail. Only valid in master account. | `string` | `"false"` | no |

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "cloudtrail_assume_role" {
 
 # This role is used by CloudTrail to send logs to CloudWatch.
 resource "aws_iam_role" "cloudtrail_cloudwatch_role" {
-  name               = "cloudtrail-cloudwatch-logs-role"
+  name               = var.role_name
   assume_role_policy = data.aws_iam_policy_document.cloudtrail_assume_role.json
 }
 

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "cloudtrail_assume_role" {
 
 # This role is used by CloudTrail to send logs to CloudWatch.
 resource "aws_iam_role" "cloudtrail_cloudwatch_role" {
-  name               = var.role_name
+  name               = var.iam_role_name
   assume_role_policy = data.aws_iam_policy_document.cloudtrail_assume_role.json
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,12 @@ variable "trail_name" {
   type        = string
 }
 
+variable "role_name" {
+  description = "Name for the Cloudtrail Role"
+  default     = "cloudtrail-cloudwatch-logs-role"
+  type        = string
+}
+
 variable "s3_key_prefix" {
   description = "S3 key prefix for CloudTrail logs"
   default     = "cloudtrail"

--- a/variables.tf
+++ b/variables.tf
@@ -39,8 +39,8 @@ variable "trail_name" {
   type        = string
 }
 
-variable "role_name" {
-  description = "Name for the Cloudtrail Role"
+variable "iam_role_name" {
+  description = "Name for the CloudTrail IAM role"
   default     = "cloudtrail-cloudwatch-logs-role"
   type        = string
 }


### PR DESCRIPTION
Based on https://github.com/trussworks/terraform-aws-cloudtrail/pull/103, this allows us to customize IAM role name associated with CloudTrail. It will also allow us to use to parallelize this module in terratests. 

Resolves https://github.com/trussworks/terraform-aws-cloudtrail/issues/108