### PR TITLE
add option to configure iam policy name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     - auth:
         password: $DOCKER_PASSWORD
         username: $DOCKER_USERNAME
-      image: trussworks/circleci:72cdc0285f434a73952ab882a0da1357c613c392
+      image: trussworks/circleci:2218890b0ada8cec21782f9799329c4422fa362b
     steps:
     - checkout
     - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.2.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,17 +12,17 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.27.1
+    rev: v0.31.1
     hooks:
       - id: markdownlint
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.50.0
+    rev: v1.68.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.39.0
+    rev: v1.45.2
     hooks:
       - id: golangci-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:
       - id: check-json
@@ -11,19 +11,18 @@ repos:
           - --autofix
       - id: trailing-whitespace
 
-  - repo: git://github.com/igorshubovych/markdownlint-cli
+  - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.27.1
     hooks:
       - id: markdownlint
 
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.50.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
-  - repo: git://github.com/golangci/golangci-lint
+  - repo: https://github.com/golangci/golangci-lint
     rev: v1.39.0
     hooks:
       - id: golangci-lint
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,4 @@ repos:
     rev: v1.45.2
     hooks:
       - id: golangci-lint
+        args: [--timeout=3m]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#input\_cloudwatch\_log\_group\_name) | The name of the CloudWatch Log Group that receives CloudTrail events. | `string` | `"cloudtrail-events"` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Enables logging for the trail. Defaults to true. Setting this to false will pause logging. | `bool` | `true` | no |
+| <a name="input_iam_policy_name"></a> [iam\_policy\_name](#input\_iam\_policy\_name) | Name for the CloudTrail IAM policy | `string` | `"cloudtrail-cloudwatch-logs-policy"` | no |
 | <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name for the CloudTrail IAM role | `string` | `"cloudtrail-cloudwatch-logs-role"` | no |
 | <a name="input_key_deletion_window_in_days"></a> [key\_deletion\_window\_in\_days](#input\_key\_deletion\_window\_in\_days) | Duration in days after which the key is deleted after destruction of the resource, must be 7-30 days.  Default 30 days. | `string` | `30` | no |
 | <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | Number of days to keep AWS logs around in specific log group. | `string` | `90` | no |

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -11,7 +11,7 @@ module "aws_cloudtrail" {
 
 module "logs" {
   source  = "trussworks/logs/aws"
-  version = "~> 10"
+  version = "~> 12"
 
   s3_bucket_name = var.logs_bucket
 

--- a/main.tf
+++ b/main.tf
@@ -58,12 +58,12 @@ data "aws_iam_policy_document" "cloudtrail_cloudwatch_logs" {
 }
 
 resource "aws_iam_policy" "cloudtrail_cloudwatch_logs" {
-  name   = "cloudtrail-cloudwatch-logs-policy"
+  name   = var.iam_policy_name
   policy = data.aws_iam_policy_document.cloudtrail_cloudwatch_logs.json
 }
 
 resource "aws_iam_policy_attachment" "main" {
-  name       = "cloudtrail-cloudwatch-logs-policy-attachment"
+  name       = "${var.iam_policy_name}-attachment"
   policy_arn = aws_iam_policy.cloudtrail_cloudwatch_logs.arn
   roles      = [aws_iam_role.cloudtrail_cloudwatch_role.name]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,12 @@ variable "iam_role_name" {
   type        = string
 }
 
+variable "iam_policy_name" {
+  description = "Name for the CloudTrail IAM policy"
+  default     = "cloudtrail-cloudwatch-logs-policy"
+  type        = string
+}
+
 variable "s3_key_prefix" {
   description = "S3 key prefix for CloudTrail logs"
   default     = "cloudtrail"


### PR DESCRIPTION
Add the ability to configure the name of the IAM policy that is created by this module.

Additionally, this fixes a bunch of issues caused by out of date versions, which were causing CI to fail.