### PR TITLE
ci: removing pr limit in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,7 +46,6 @@
   "postUpdateOptions": [
     "gomodTidy"
   ],
-  "prConcurrentLimit": 2,
   "schedule": [
     "every weekend"
   ],


### PR DESCRIPTION
Removing prConcurrentLimit in renovate to allow it to open as many PRs as it needs to.
