### PR TITLE
feat(insights): allow enabling available insights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .terraform
+.terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
 terraform.tfstate.*.backup

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| api\_call\_rate\_insight | A measurement of write-only management API calls that occur per minute against a baseline API call volume. | `bool` | `false` | no |
+| api\_error\_rate\_insight | A measurement of management API calls that result in error codes. The error is shown if the API call is unsuccessful. | `bool` | `false` | no |
 | cloudwatch\_log\_group\_name | The name of the CloudWatch Log Group that receives CloudTrail events. | `string` | `"cloudtrail-events"` | no |
 | enabled | Enables logging for the trail. Defaults to true. Setting this to false will pause logging. | `bool` | `true` | no |
 | iam\_policy\_name | Name for the CloudTrail IAM policy | `string` | `"cloudtrail-cloudwatch-logs-policy"` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,7 @@ variable "s3_key_prefix" {
   default     = "cloudtrail"
   type        = string
 }
+
 variable "sns_topic_arn" {
   description = "ARN of the SNS topic for notification of log file delivery."
   default     = ""
@@ -66,4 +67,16 @@ variable "tags" {
   description = "A mapping of tags to CloudTrail resources."
   default     = {}
   type        = map(string)
+}
+
+variable "api_call_rate_insight" {
+  description = "A measurement of write-only management API calls that occur per minute against a baseline API call volume."
+  default     = false
+  type        = bool
+}
+
+variable "api_error_rate_insight" {
+  description = "A measurement of management API calls that result in error codes. The error is shown if the API call is unsuccessful."
+  default     = false
+  type        = bool
 }


### PR DESCRIPTION
Currently, the module does not allow enabling [CloudTrail Insights](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-insights-events-with-cloudtrail.html), and this PR allows enabling them by type. Meanwhile, by default, insights are disabled.