### PR TITLE
Support an S3 bucket in a different account

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ No modules.
 | key\_deletion\_window\_in\_days | Duration in days after which the key is deleted after destruction of the resource, must be 7-30 days.  Default 30 days. | `string` | `30` | no |
 | log\_retention\_days | Number of days to keep AWS logs around in specific log group. | `string` | `90` | no |
 | org\_trail | Whether or not this is an organization trail. Only valid in master account. | `string` | `"false"` | no |
+| s3\_bucket\_account\_id | (optional) The AWS account ID which owns the S3 bucket. Only include if the S3 bucket is in a different account than the CloudTrail. | `string` | `null` | no |
 | s3\_bucket\_name | The name of the AWS S3 bucket. | `string` | n/a | yes |
 | s3\_key\_prefix | S3 key prefix for CloudTrail logs | `string` | `"cloudtrail"` | no |
 | sns\_topic\_arn | ARN of the SNS topic for notification of log file delivery. | `string` | `""` | no |
@@ -83,6 +84,7 @@ No modules.
 | cloudtrail\_arn | CloudTrail ARN |
 | cloudtrail\_home\_region | CloudTrail Home Region |
 | cloudtrail\_id | CloudTrail ID |
+| kms\_key\_arn | KMS Key ARN |
 <!-- END_TF_DOCS -->
 
 ## Developer Setup

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,10 @@ data "aws_caller_identity" "current" {}
 # The AWS partition (commercial or govcloud)
 data "aws_partition" "current" {}
 
+locals {
+  s3_bucket_account_id = var.s3_bucket_account_id != null ? var.s3_bucket_account_id : data.aws_caller_identity.current.account_id
+}
+
 #
 # CloudTrail - CloudWatch
 #
@@ -191,7 +195,7 @@ data "aws_iam_policy_document" "cloudtrail_kms_policy_doc" {
     condition {
       test     = "StringEquals"
       variable = "kms:CallerAccount"
-      values   = [data.aws_caller_identity.current.account_id]
+      values   = [local.s3_bucket_account_id]
     }
 
     condition {

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,8 @@ output "cloudtrail_id" {
   description = "CloudTrail ID"
   value       = aws_cloudtrail.main.id
 }
+
+output "kms_key_arn" {
+  description = "KMS Key ARN"
+  value       = aws_kms_key.cloudtrail.arn
+}

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,12 @@ variable "s3_bucket_name" {
   type        = string
 }
 
+variable "s3_bucket_account_id" {
+  description = "(optional) The AWS account ID which owns the S3 bucket. Only include if the S3 bucket is in a different account than the CloudTrail."
+  default     = null
+  type        = string
+}
+
 variable "org_trail" {
   description = "Whether or not this is an organization trail. Only valid in master account."
   default     = "false"


### PR DESCRIPTION
Allow principals in the S3 bucket's account to use the KMS Key to decrypt logs.

S3 itself cannot tell us which account an arbitrary bucket is in, so the caller must provide it.

Useful when using an Organization CloudTrail and a dedicated AWS account for logs, as recommended by [AWS Multi-account strategy](https://docs.aws.amazon.com/whitepapers/latest/organizing-your-aws-environment/organizing-your-aws-environment.html).

Fixes #240 

## [logs encrypted with other aws account cmk](https://github.com/trussworks/terraform-aws-cloudtrail/issues/240)

Changes proposed in this pull request:

- Optionally give permission to a caller-provided AWS Account number to the KMS key for decryption