### PR TITLE
Support Advanced Field Selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| advanced\_event\_selectors | A list of advanced event selectors for the trail. | ```list(object({ name = string field_selectors = list(object({ field = string equals = optional(list(string)) starts_with = optional(list(string)) ends_with = optional(list(string)) not_equals = optional(list(string)) not_starts_with = optional(list(string)) not_ends_with = optional(list(string)) })) }))``` | `[]` | no |
 | api\_call\_rate\_insight | A measurement of write-only management API calls that occur per minute against a baseline API call volume. | `bool` | `false` | no |
 | api\_error\_rate\_insight | A measurement of management API calls that result in error codes. The error is shown if the API call is unsuccessful. | `bool` | `false` | no |
 | cloudwatch\_log\_group\_name | The name of the CloudWatch Log Group that receives CloudTrail events. | `string` | `"cloudtrail-events"` | no |

--- a/main.tf
+++ b/main.tf
@@ -296,6 +296,26 @@ resource "aws_cloudtrail" "main" {
     }
   }
 
+  dynamic "advanced_event_selector" {
+    for_each = var.advanced_event_selectors
+    content {
+      name = advanced_event_selector.value.name
+
+      dynamic "field_selector" {
+        for_each = advanced_event_selector.value.field_selectors
+        content {
+          field           = field_selector.value.field
+          equals          = field_selector.value.equals
+          starts_with     = field_selector.value.starts_with
+          ends_with       = field_selector.value.ends_with
+          not_equals      = field_selector.value.not_equals
+          not_starts_with = field_selector.value.not_starts_with
+          not_ends_with   = field_selector.value.not_ends_with
+        }
+      }
+    }
+  }
+
   tags = var.tags
 
   depends_on = [

--- a/variables.tf
+++ b/variables.tf
@@ -80,3 +80,20 @@ variable "api_error_rate_insight" {
   default     = false
   type        = bool
 }
+
+variable "advanced_event_selectors" {
+  description = "A list of advanced event selectors for the trail."
+  default     = []
+  type = list(object({
+    name = string
+    field_selectors = list(object({
+      field           = string
+      equals          = optional(list(string))
+      starts_with     = optional(list(string))
+      ends_with       = optional(list(string))
+      not_equals      = optional(list(string))
+      not_starts_with = optional(list(string))
+      not_ends_with   = optional(list(string))
+    }))
+  }))
+}


### PR DESCRIPTION
Allow the caller to provide [advanced event selectors](https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_AdvancedFieldSelector.html) to e.g. log S3 data plane events (GetObject, etc).

## [Trello Card Title](URL)

Changes proposed in this pull request:

- Change 1
- Change 2
